### PR TITLE
Rename FL graph to LN in efficiency analysis

### DIFF
--- a/intelligent_systems/analisis_eficiencia/templates/analisis_comparativo.html
+++ b/intelligent_systems/analisis_eficiencia/templates/analisis_comparativo.html
@@ -24,7 +24,7 @@
     <h2 class="text-2xl font-semibold text-blue-600 mb-4">Respuestas de encuesta (Conocimiento) - Profesores</h2>
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
         <div class="bg-blue-50 p-4 rounded-lg shadow">
-            <h3 class="text-lg font-medium text-blue-700 mb-2">Lógica Difusa (FL)</h3>
+            <h3 class="text-lg font-medium text-blue-700 mb-2">Lógica Neutrosófica (LN)</h3>
             <canvas id="profesores-logica-difusa" class="w-full h-64"></canvas>
         </div>
         <div class="bg-blue-50 p-4 rounded-lg shadow">
@@ -32,7 +32,7 @@
             <canvas id="profesores-ast" class="w-full h-64"></canvas>
         </div>
         <div class="bg-blue-50 p-4 rounded-lg shadow">
-            <h3 class="text-lg font-medium text-blue-700 mb-2">Comparación AST y FL (Profesores)</h3>
+            <h3 class="text-lg font-medium text-blue-700 mb-2">Comparación AST y LN (Profesores)</h3>
             <canvas id="comparacion-encuesta-profesores" class="w-full h-64"></canvas>
         </div>
     </div>
@@ -43,7 +43,7 @@
     <h2 class="text-2xl font-semibold text-blue-600 mb-4">Respuestas de encuesta (Satisfacción) - Estudiantes</h2>
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
         <div class="bg-blue-50 p-4 rounded-lg shadow">
-            <h3 class="text-lg font-medium text-blue-700 mb-2">Lógica Difusa (FL)</h3>
+            <h3 class="text-lg font-medium text-blue-700 mb-2">Lógica Neutrosófica (LN)</h3>
             <canvas id="estudiantes-logica-difusa" class="w-full h-64"></canvas>
         </div>
         <div class="bg-blue-50 p-4 rounded-lg shadow">
@@ -51,7 +51,7 @@
             <canvas id="estudiantes-ast" class="w-full h-64"></canvas>
         </div>
         <div class="bg-blue-50 p-4 rounded-lg shadow">
-            <h3 class="text-lg font-medium text-blue-700 mb-2">Comparación AST y FL (Estudiantes)</h3>
+            <h3 class="text-lg font-medium text-blue-700 mb-2">Comparación AST y LN (Estudiantes)</h3>
             <canvas id="comparacion-encuesta-estudiantes" class="w-full h-64"></canvas>
         </div>
     </div>
@@ -75,7 +75,7 @@
             <div id="matrizAst" class="w-full h-64"></div>
         </div>
         <div class="bg-blue-50 p-4 rounded-lg shadow">
-            <h3 class="text-lg font-medium text-blue-700 mb-2">Matriz de Confusión (FL)</h3>
+            <h3 class="text-lg font-medium text-blue-700 mb-2">Matriz de Confusión (LN)</h3>
             <div id="matrizFl" class="w-full h-64"></div>
         </div>
         <div class="bg-blue-50 p-4 rounded-lg shadow">
@@ -222,7 +222,7 @@ document.addEventListener("DOMContentLoaded", () => {
                                 const dataComparacion = [...new Set(response.data.comparation_values)];
                                 const labels = [...new Set(dataComparacion.map(item => item.materia))];
                                 const astData = dataComparacion.filter(item => item.algoritmo === 'Árbol de Sintaxis Abstracta').map(item => item.probabilidad);
-                                const lfData = dataComparacion.filter(item => item.algoritmo === 'Lógica Difusa').map(item => item.probabilidad);
+                                const lfData = dataComparacion.filter(item => item.algoritmo === 'Lógica Neutrosófica').map(item => item.probabilidad);
                                 const ctxComparacion = document.getElementById('comparacion-encuesta-profesores').getContext('2d');
                                 chartComparacion = new Chart(ctxComparacion, {
                                 type: 'bar',
@@ -235,7 +235,7 @@ document.addEventListener("DOMContentLoaded", () => {
                                         backgroundColor: 'rgba(75, 192, 192, 0.6)',
                                     },
                                     {
-                                        label: 'Lógica Difusa',
+                                        label: 'Lógica Neutrosófica (LN)',
                                         data: lfData,
                                         backgroundColor: 'rgba(255, 99, 132, 0.6)',
                                     },
@@ -339,7 +339,7 @@ document.addEventListener("DOMContentLoaded", () => {
                                 const dataComparacionEstudiante = [...new Set(responseEstudiante.data.comparation_values)];
                                 const labelsEst = [...new Set(dataComparacionEstudiante.map(item => item.materia))];
                                 const astDataEst = dataComparacionEstudiante.filter(item => item.algoritmo === 'Árbol de Sintaxis Abstracta').map(item => item.probabilidad);
-                                const lfDataEst = dataComparacionEstudiante.filter(item => item.algoritmo === 'Lógica Difusa').map(item => item.probabilidad);
+                                const lfDataEst = dataComparacionEstudiante.filter(item => item.algoritmo === 'Lógica Neutrosófica').map(item => item.probabilidad);
                                 const ctxComparacionEst = document.getElementById('comparacion-encuesta-estudiantes').getContext('2d');
                                 chartComparacionEst = new Chart(ctxComparacionEst, {
                                 type: 'bar',
@@ -352,7 +352,7 @@ document.addEventListener("DOMContentLoaded", () => {
                                         backgroundColor: 'rgba(75, 192, 192, 0.6)',
                                     },
                                     {
-                                        label: 'Lógica Difusa',
+                                        label: 'Lógica Neutrosófica (LN)',
                                         data: lfDataEst,
                                         backgroundColor: 'rgba(255, 99, 132, 0.6)',
                                     },
@@ -443,7 +443,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
                                 // Configuración del layout
                                 const layoutFL = {
-                                    title: `${'FL'}<br>Recall: ${dataFL.recall?.toFixed(2)}`,
+                                    title: `${'LN'}<br>Recall: ${dataFL.recall?.toFixed(2)}`,
                                     xaxis: {
                                         title: 'Valores Predicción',
                                         tickvals: [0, 1],
@@ -494,7 +494,7 @@ document.addEventListener("DOMContentLoaded", () => {
                                 chartRecall = new Chart(recallComparativo, {
                                     type: 'bar',
                                     data: {
-                                        labels: ['AST', 'FL'],
+                                        labels: ['AST', 'LN'],
                                         datasets: [{
                                             label: 'Recall',
                                             data: [respuestaMatrizConfucion.data.AST.recall, respuestaMatrizConfucion.data.FL.recall],

--- a/intelligent_systems/analisis_eficiencia/views.py
+++ b/intelligent_systems/analisis_eficiencia/views.py
@@ -52,7 +52,7 @@ def obtener_resultados_encuesta_estudiantes(request):
     for item in top_ast:
         item['algoritmo'] = 'Árbol de Sintaxis Abstracta'
     for item in top_fl:
-        item['algoritmo'] = 'Lógica Difusa'
+        item['algoritmo'] = 'Lógica Neutrosófica'
 
 
     return JsonResponse({
@@ -88,7 +88,7 @@ def obtener_resultados_encuesta_profesores(request):
     for item in top_ast:
         item['algoritmo'] = 'Árbol de Sintaxis Abstracta'
     for item in top_fl:
-        item['algoritmo'] = 'Lógica Difusa'
+        item['algoritmo'] = 'Lógica Neutrosófica'
 
 
     return JsonResponse({


### PR DESCRIPTION
## Summary
- filter comparison charts by *Lógica Neutrosófica* instead of *Lógica Difusa*
- update efficiency analysis view to tag results with *Lógica Neutrosófica*

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ab096f4848328bbf21f13de1bae85